### PR TITLE
Exit codes from task table gives explanations only for that task

### DIFF
--- a/runserver/workflowtools.py
+++ b/runserver/workflowtools.py
@@ -335,7 +335,8 @@ class WorkflowTools(object):
 
         workflow = workflowstep.split('/')[1]
         if workflow:
-            errs_explained = globalerrors.check_session(cherrypy.session).get_workflow(workflow).get_explanation(errorcode)
+            errs_explained = globalerrors.check_session(cherrypy.session).\
+                get_workflow(workflow).get_explanation(errorcode, workflowstep)
         else:
             errs_explained = globalerrors.check_session(cherrypy.session).\
                 get_errors_explained().get(errorcode, ['No info for this error code'])


### PR DESCRIPTION
Most of the improvement is in the workflowinfo class in CMSToolBox. https://github.com/CMSCompOps/OpsSpace/pull/40