### PR TITLE
Catch zero sites

### DIFF
--- a/manageactions.py
+++ b/manageactions.py
@@ -59,8 +59,7 @@ def extract_reasons_params(action, **kwargs):
                 default = 'AllSteps' if parameter != 'sites' else 'Ban'
                 which_task = kwargs.get('task_%s' % key.split('_')[1], default)
 
-                if not params.get(which_task):
-                    params[which_task] = {}
+                params[which_task] = params.get(which_task, {})
 
                 if parameter == 'sites' and not isinstance(item, list):
                     item = [item]

--- a/manageactions.py
+++ b/manageactions.py
@@ -239,8 +239,6 @@ def fix_sites(**kwargs):
         output['Parameters'][subtask]['sites'] = value['sites']
 
         coll.update_one({'workflow': workflow},
-                        {'$set': {'parameters': output}},
-                        upsert=True)
-
+                        {'$set': {'parameters': output}})
 
     print params

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,5 @@ bcrypt
 pyOpenSSL
 pyyaml
 validators
-nltk
 tabulate
 pymongo
-MySQL-python
-h5py

--- a/runserver/templates/picksites.html
+++ b/runserver/templates/picksites.html
@@ -1,0 +1,53 @@
+<%inherit file="simple.html"/>
+
+<%block name="title">Action Submitted</%block>
+
+<%block name="scripts">
+<script type="text/javascript">
+  var task_list = [
+  % for task in tasks:
+  "${task}",
+  % endfor
+  ];
+  var sitelist = [
+  % for site in sorted(statuses.keys()):
+  "${site}",
+  % endfor
+  ];
+  var sites_for_task = {
+  % for step, sites in sites_to_run.iteritems():
+  "${step}": [
+  % for site in sites:
+  "${site}",
+  % endfor
+  ],
+  % endfor
+  };
+  var drain_statuses = {
+  % for site, stat in statuses.iteritems():
+  "${site}": "${stat}",
+  % endfor
+  };
+</script>
+<script src="/static/js/makeparams.js"></script>
+<link rel="stylesheet" type="text/css" href="/static/css/workflow.css">
+</%block>
+
+<h2>Following Subtasks Have No Sites</h2>
+
+Please manually pick sites for each task.
+
+<div id="site_table_${len(tasks)}"></div>
+
+<form method="POST" action="/sitesfortasks">
+% for index, subtask in enumerate(tasks):
+<h3>${subtask}</h3>
+<input type="hidden" name="task_${index}" value="${subtask}">
+<div id="site_table_${index}"></div>
+% endfor
+<input type="submit" value="Submit">
+</form>
+
+<script type="text/javascript">
+  printSiteLists({'value': 'Manual'});
+</script>

--- a/runserver/templates/simple.html
+++ b/runserver/templates/simple.html
@@ -10,7 +10,6 @@
 
   <body>
     ${self.body()}
-  </body>
 
   <footer>
     <center>
@@ -19,5 +18,6 @@
       <a href="/cluster">Update server cluster definition</a>
     </center>
   </footer>
+  </body>
 
 </html>

--- a/runserver/templates/workflowtables.html
+++ b/runserver/templates/workflowtables.html
@@ -17,7 +17,7 @@
       % endfor
       };
       var sitelist = [
-      % for site in site_list:
+      % for site in sorted(drain_statuses.keys()):
         "${site}",
       % endfor
       ];

--- a/runserver/workflowtools.py
+++ b/runserver/workflowtools.py
@@ -235,6 +235,22 @@ class WorkflowTools(object):
                   )
 
     @cherrypy.expose
+    @cherrypy.tools.json_out()
+    def sitesfortasks(self, **kwargs):
+        """
+        Accessed through a popup that allows user to submit sites for workflow
+        tasks that did not have any sites to run on.
+        Returns operators back the :py:func:`get_action` output.
+
+        :param kwargs: Set up in a way that manageactions.extract_reasons_params
+                       can extract the sites for each subtask.
+        :rtype: JSON
+        """
+
+        manageactions.fix_sites(**kwargs)
+        return self.getaction(1)
+
+    @cherrypy.expose
     def submitaction(self, workflows='', action='', **kwargs):
         """Submits the action to Unified and notifies the user that this happened
 
@@ -540,7 +556,7 @@ if __name__ == '__main__':
         'tools.auth_basic.realm': 'localhost',
         'tools.auth_basic.checkpassword': manageusers.validate_password
         }
-    for key in ['/cluster', '/resetcache']:
+    for key in ['/cluster', '/resetcache', '/sitesfortasks']:
         CONF[key] = CONF['/submitaction']
 
     cherrypy.quickstart(WorkflowTools(), '/', CONF)


### PR DESCRIPTION
When recovery actions are submitted, especially for multiple workflows simultaneously, there can be some subtasks that end up with no sites assigned. This update causes a page to pop up to indicate which workflow tasks have zero sites running at them. From this page, the operator has to manually select sites for now.