### PR TITLE
Implemented refresh feature, but wasn't using it.

### DIFF
--- a/clusterworkflows.py
+++ b/clusterworkflows.py
@@ -67,7 +67,7 @@ def get_workflow_vectors(workflows, session=None, allmap=None):
     :return: a list of numpy arrays of errors for the workflow
     :rtype: list of numpy.array
     """
-    curs = globalerrors.check_session(session).curs
+    curs = globalerrors.check_session(session, can_refresh=True).curs
     if not allmap:
         allmap = globalerrors.check_session(session).get_allmap()
 
@@ -164,7 +164,7 @@ def get_workflow_groups(clusterer, session=None):
     :rtype: List of sets
     """
 
-    errorinfo = globalerrors.check_session(session)
+    errorinfo = globalerrors.check_session(session, can_refresh=True)
 
     if errorinfo.clusters:
         return errorinfo.clusters

--- a/globalerrors.py
+++ b/globalerrors.py
@@ -442,7 +442,7 @@ def list_matching_pievars(pievar, row, col, session=None):
     :rtype: list
     """
 
-    curs = check_session(session, True).curs
+    curs = check_session(session, can_refresh=True).curs
     rowname, colname = get_row_col_names(pievar)
 
     output = []
@@ -475,7 +475,7 @@ def get_errors(pievar, session=None):
     """
 
     rowname, colname = get_row_col_names(pievar)
-    allmap = check_session(session).get_allmap()
+    allmap = check_session(session, can_refresh=True).get_allmap()
 
     query = 'SELECT numbererrors, {0}, {1}, {2} FROM workflows ' \
         'ORDER BY {0} ASC, {1} ASC, {2} ASC;'.format(rowname, colname, pievar)

--- a/runserver/workflowtools.py
+++ b/runserver/workflowtools.py
@@ -230,7 +230,7 @@ class WorkflowTools(object):
                  is not selected.
         """
 
-        if workflow not in globalerrors.check_session(cherrypy.session).return_workflows():
+        if workflow not in globalerrors.check_session(cherrypy.session, can_refresh=True).return_workflows():
             raise cherrypy.HTTPRedirect('/globalerror')
 
         if issuggested:
@@ -513,6 +513,7 @@ class WorkflowTools(object):
         :returns: a confirmation page
         :rtype: str
         """
+        # Force the cache reset
         if cherrypy.session.get('info'):
             cherrypy.session.get('info').teardown()
             cherrypy.session.get('info').setup()


### PR DESCRIPTION
I wasn't using the refresh flag when I should have been. This should keep the globalerror page up to date.