### PR TITLE
Remove empty errored ACDC

### DIFF
--- a/globalerrors.py
+++ b/globalerrors.py
@@ -93,8 +93,12 @@ class ErrorInfo(object):
             self.set_all_lists()
             current_workflows = self.return_workflows()
 
-            self.allsteps.extend(['/%s/' % zero for zero in other_workflows \
-                                      if zero not in current_workflows])
+            # If all ACDCs are to be shown, include the ones with zero errors like this
+            if serverconfig.config_dict().get('include_all_acdcs'):
+                self.allsteps.extend(['/%s/' % zero for zero in other_workflows \
+                                          if zero not in current_workflows])
+                self.allsteps.sort()
+
             self.readiness = [sitereadiness.site_readiness(site) for site in self.info[3]]
 
         self.connection_log('opened')

--- a/runserver/create_actionshistorylink.py
+++ b/runserver/create_actionshistorylink.py
@@ -11,13 +11,13 @@ with saved historic information into a json file.
 
 import sys
 
-if __name__ == '__main__' and len(sys.argv) == 1:
-    print '\nUsage:  %s <output_file_name>\n' % sys.argv[0]
-    exit(1)
-
-from WorkflowWebTools import actionshistorylink
-
 if __name__ == '__main__':
+    if len(sys.argv) == 1:
+        print '\nUsage:  %s <output_file_name>\n' % sys.argv[0]
+        exit(1)
 
-    actionshistorylink.serverconfig.LOCATION = '.'
+    from WorkflowWebTools import serverconfig
+    serverconfig.LOCATION = '.'
+
+    from WorkflowWebTools import actionshistorylink
     actionshistorylink.dump_json(sys.argv[1])

--- a/runserver/templates/workflowtables.html
+++ b/runserver/templates/workflowtables.html
@@ -103,7 +103,7 @@
       Sub-Request Type: ${params['SubRequestType']} <br>
       % endif
       Memory: ${params['Memory']} <br>
-      Estimated Number of Jobs: ${params['TotalEstimatedJobs']}
+      Estimated Number of Jobs: ${params.get('TotalEstimatedJobs', '?')}
       % else:
       <span style="color:red;">Problem retrieving info (likely an expired certificate, use link above)</span>
       % endif


### PR DESCRIPTION
ACDCs without errors can now be shown through a flag. The default behavior is to have that flag off.