### PR TITLE
scipy developers don't know how to do a proper release.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cherrypy
 mako
 numpy>=1.6.1
-scipy>=0.9
+scipy==0.19.1
 sklearn
 passlib>=1.6
 bcrypt


### PR DESCRIPTION
Travis builds are failing for all builds due to wheel problem messing up the documentation generation.