### PR TITLE
Use old CherryPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 cache: pip
 python: 2.7
-sudo: required
 dist: trusty
 services:
   - mongodb

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
         },
     install_requires=[
         'cmstoolbox',
-        'cherrypy',
+        'cherrypy<18.0.0',
         'mako',
         'numpy>=1.6.1',
         'scipy>=0.19.1',


### PR DESCRIPTION
- Don't need to require sudo anymore. Travis has trouble with those machines semi-regularly.
- CherryPy v18.0.0 dropped support for Python 2.7, so we need to require v17