### PR TITLE
improve tooltip on globalerror page by using jQuery ui

### DIFF
--- a/workflowwebtools/web/static/css/globalerror.css
+++ b/workflowwebtools/web/static/css/globalerror.css
@@ -1,12 +1,4 @@
-a span {
-    display: none;
-    position: absolute;
-    color: #ff0;
-    background: #000;
-    padding: 5px;
-}
-
-a:hover span {
-    display: block;
-    text-align: right;
+.ui-tooltip {
+    max-width: 500px;
+    font-family: monospace;
 }

--- a/workflowwebtools/web/static/js/piechart.js
+++ b/workflowwebtools/web/static/js/piechart.js
@@ -204,8 +204,6 @@ function drawPies () {
                     canvas.height = '20';
 
                     anchor.appendChild(canvas);
-                    var tooltip = document.createElement('span');
-                    anchor.appendChild(tooltip);
                     var tooltiptext = '';
 
                     // Count the size of the pie here and create canvas and sorting objects
@@ -242,8 +240,8 @@ function drawPies () {
                         }
                         anchor.target = '_blank';
 
-                        tooltiptext += 'total: ' + count;
-                        tooltip.innerHTML = tooltiptext;
+                        tooltiptext += '<br><strong>total: ' + count + '</strong>';
+                        anchor.setAttribute('title', tooltiptext);
                     }
                     else
                         anchor.innerHTML = '';
@@ -302,7 +300,8 @@ function pieOn () {
 
       This function replace the default drawing circles with pie chart
       on canvases, when the "Draw pie" checkbox is toggled on.
-      Radius and color please refer to above `drawPies()` function.
+
+      Radius and color please refer to above :js:func:`drawPies` function.
 
      */
 
@@ -357,7 +356,8 @@ function pieOff () {
 
       This function replace the pie charts with circles
       on canvases, when the "Draw pie" checkbox is toggled off.
-      Radius please refer to above `drawPies()` function.
+
+      Radius please refer to above :js:func:`drawPies` function.
       Color indicates the most contributing error code.
 
      */
@@ -410,6 +410,30 @@ $(document).ready(function(){
     drawPies();
     document.getElementById('wait-message').style.display = 'none';
 
+    $("a").tooltip({
+        position: {
+            my: 'left top+5'
+        },
+        content: function() {
+            var element = this;
+            var text = $(element).attr('title');
+            var maxTextLen = 0;
+            text.split('<br>').forEach(function(t) {
+                if (t.length > maxTextLen) {
+                    maxTextLen = t.length;
+                }
+            });
+            return "<p  style='text-align: right; width: "+maxTextLen*0.5+"em; max-width: 500px'>"+text+"</p>";
+        }
+    });
+
+    $("a").hover(
+        function() {
+            $( this ).parent().css("background-color", "#E8E8E8");
+        }, function() {
+            $( this ).parent().css("background-color", "white");
+        }
+    );
 
     $("#switch").on('click', function(){
         var check = this;

--- a/workflowwebtools/web/templates/globalerror.html
+++ b/workflowwebtools/web/templates/globalerror.html
@@ -39,7 +39,7 @@ for row_name, row in sorted(errors.items()):
   <head>
     <title>4D Errors</title>
     <%include file="rotation_tables.html"/>
-    <link rel="stylesheet" href="//code.jquery.com/ui/1.11.4/themes/smoothness/jquery-ui.css"/>
+    <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css"/>
     <link rel="stylesheet" href="static/css/globalerror.css"/>
     <script type="text/javascript" src="static/js/pako_inflate.min.js"></script>
     <script type="text/javascript" src="static/js/expandtable.js"></script>

--- a/workflowwebtools/web/templates/rotation_tables.html
+++ b/workflowwebtools/web/templates/rotation_tables.html
@@ -1,3 +1,3 @@
   <link rel="stylesheet" type="text/css" href="/static/css/rotation.css"/>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script> 
-  <script src="//code.jquery.com/ui/1.11.4/jquery-ui.js"></script>
+  <script src="//code.jquery.com/ui/1.12.1/jquery-ui.min.js" integrity="sha256-VazP97ZCwtekAsvgPBSUwPFKdrwD3unUfSGVYrahUqU=" crossorigin="anonymous"></script>


### PR DESCRIPTION
it was always displaced bottom right of the hovered element, would be hard to read if the hovered element is on the rightmost column or bottom row;

jQuery ui tooltip has automatic reflex option, which is convenient, also possible to display more types of content if needed in the future.